### PR TITLE
feat: compare date instead of strings

### DIFF
--- a/labman/src/components/loans/EditLoan.tsx
+++ b/labman/src/components/loans/EditLoan.tsx
@@ -149,9 +149,9 @@ export default function EditLoan({loan, setLoans}: EditLoanProps) {
                                 min={formData.startDate.toISOString().split("T")[0]}
                                 className="side-form-input"
                                 onChange={(e) => {
-                                    const selected = e.target.value;
-                                    if (selected < formData.startDate.toLocaleDateString()) return;
-                                    setFormData({...formData, endDate: new Date(selected)});
+                                    const selected = new Date(e.target.value);
+                                    if (selected < formData.startDate) return;
+                                    setFormData({...formData, endDate: selected});
 
                                 }}
                             />


### PR DESCRIPTION
when editing return date convert the selected date to a date to correctly compare with the loan start date

Refs: #79